### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anapsix/alpine-java:7
+FROM anapsix/alpine-java:8
 MAINTAINER Shiaupiau <stu43005@gmail.com>
 
 ENV HatH_PORT 11112


### PR DESCRIPTION
Apologies; H@H 1.6.0 requires Java 8. Much breakage ensued.